### PR TITLE
Key laptop panel by connector name so Omarchy clamshell keeps scale

### DIFF
--- a/scripts/display-ctl
+++ b/scripts/display-ctl
@@ -815,12 +815,21 @@ def sanitize_monitor(mon, known_names=None):
     }
 
 
+INTERNAL_PANEL_RE = re.compile(r"^(eDP|LVDS|DSI)", re.I)
+
+
 def output_ref(mon, used_desc):
+    name = clean_connector(mon.get("name"))
+    # omarchy-hyprland-monitor-clamshell only reads the internal panel's rule
+    # when it is keyed by connector name. Behind a desc: key it finds no scale,
+    # falls back to 2, and re-applies it every 2s while docked.
+    if name and INTERNAL_PANEL_RE.match(name):
+        return name
     desc = clean_desc(mon.get("description") or "")
     if desc and desc not in used_desc:
         used_desc.add(desc)
         return "desc:%s" % desc
-    return clean_connector(mon.get("name")) or "Unknown"
+    return name or "Unknown"
 
 
 def monitor_lua(mon, used_desc):


### PR DESCRIPTION
## Summary
- Write internal panels (`eDP` / `LVDS` / `DSI`) with the connector name instead of `desc:` in `monitors.lua`.
- Fixes scale/position being reverted to Omarchy’s hardcoded `2` / `auto` every ~2s while docked, because `omarchy-hyprland-monitor-clamshell` only matches `output = "eDP-1"` (etc.).
- External monitors still use `desc:` so port changes stay stable.

Closes #1

## Test plan
- [ ] Docked laptop + external display, set internal panel to 100% in Screens and apply
- [ ] Confirm `hyprctl monitors` keeps `scale=1` for >5s (no revert to 2)
- [ ] Confirm internal rule in `~/.config/hypr/monitors.lua` uses `output = "eDP-1"` (or equivalent), not `desc:`
- [ ] External monitor rules still use `desc:` and keep their scale/HDR/VRR settings
- [ ] Undock / redock and confirm profile restore still works for the laptop panel


Made with [Cursor](https://cursor.com)