### PR TITLE
1.5.0: layout, HDR Tune, Display controls, backups

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -23,6 +23,13 @@ function clone(monitors) {
       hdr: m.hdr,
       hdrCapable: m.hdrCapable,
       vrrCapable: m.vrrCapable,
+      bitdepth: m.bitdepth,
+      bitdepthCapable: m.bitdepthCapable,
+      sdrMinLuminance: m.sdrMinLuminance,
+      sdrMaxLuminance: m.sdrMaxLuminance,
+      minLuminance: m.minLuminance,
+      maxLuminance: m.maxLuminance,
+      maxAvgLuminance: m.maxAvgLuminance,
       logicalW: m.logicalW,
       logicalH: m.logicalH,
       mode: m.mode,
@@ -223,6 +230,12 @@ function applyPayload(monitors) {
       transform: m.transform,
       vrr: m.vrr,
       hdr: !!m.hdr,
+      bitdepth: m.bitdepth,
+      cm: m.cm,
+      sdrMinLuminance: m.sdrMinLuminance,
+      sdrMaxLuminance: m.sdrMaxLuminance,
+      minLuminance: m.minLuminance,
+      maxLuminance: m.maxLuminance,
       enabled: !!m.enabled,
       identity: m.identity,
       mirror: m.mirror || ""
@@ -288,7 +301,7 @@ function heroStatus(mon, profileName) {
   if (res) bits.push(res.replace("x", "×"))
   var hz = Number(mon.refresh)
   if (isFinite(hz) && hz > 0) bits.push(Math.round(hz) + " Hz")
-  if (mon.hdr) bits.push("HDR")
+  if (mon.hdr) bits.push(Number(mon.bitdepth) === 8 ? "HDR 8" : "HDR")
   if (Number(mon.vrr) === 1) bits.push("VRR")
   else if (Number(mon.vrr) === 2) bits.push("VRR FS")
   else if (Number(mon.vrr) === 3) bits.push("VRR GAME")
@@ -305,6 +318,21 @@ function mirrorOptions(monitors, selected) {
     out.push({ value: m.name, label: m.label || m.name })
   }
   return out
+}
+
+function hdrDescription(mon) {
+  if (!mon) return "PQ"
+  var bits = Number(mon.bitdepth) === 8 ? "8-bit" : "10-bit"
+  var cm = String(mon.cm || "") === "hdredid" ? "PQ · EDID" : "PQ"
+  return bits + " " + cm
+}
+
+function defaultSdrPeak(mon) {
+  var avg = Number(mon && mon.maxAvgLuminance)
+  if (isFinite(avg) && avg >= 80 && avg <= 400) return Math.round(avg)
+  var peak = Number(mon && mon.maxLuminance)
+  if (isFinite(peak) && peak >= 80 && peak <= 400) return Math.round(peak)
+  return 200
 }
 
 function profileOptions(profiles) {
@@ -329,6 +357,8 @@ if (typeof module !== "undefined") {
     normalizeOrigin: normalizeOrigin,
     applyPayload: applyPayload,
     pickMode: pickMode,
-    heroStatus: heroStatus
+    heroStatus: heroStatus,
+    hdrDescription: hdrDescription,
+    defaultSdrPeak: defaultSdrPeak
   }
 }

--- a/Model.js
+++ b/Model.js
@@ -327,6 +327,24 @@ function hdrDescription(mon) {
   return bits + " " + cm
 }
 
+function clampBrightness(value) {
+  var n = Number(value)
+  if (!isFinite(n)) return 1
+  return Math.max(1, Math.min(100, Math.round(n)))
+}
+
+function brightnessName(percent) {
+  var p = Math.round(percent)
+  if (p >= 95) return "Sun blast"
+  if (p >= 80) return "Solar flare"
+  if (p >= 65) return "Golden hour"
+  if (p >= 45) return "Even day"
+  if (p >= 30) return "Soft glow"
+  if (p >= 20) return "Lamp light"
+  if (p >= 10) return "Candlelit"
+  return "Night owl"
+}
+
 function defaultSdrPeak(mon) {
   var avg = Number(mon && mon.maxAvgLuminance)
   if (isFinite(avg) && avg >= 80 && avg <= 400) return Math.round(avg)
@@ -359,6 +377,8 @@ if (typeof module !== "undefined") {
     pickMode: pickMode,
     heroStatus: heroStatus,
     hdrDescription: hdrDescription,
-    defaultSdrPeak: defaultSdrPeak
+    defaultSdrPeak: defaultSdrPeak,
+    clampBrightness: clampBrightness,
+    brightnessName: brightnessName
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ cd omarchy-screens
 - **Find** — badge on the *selected* output (not only the screen that holds the menu)
 - **Detect** — rescan Hyprland and DRM for a plugged-in screen that is currently off, then **Turn on**. If it is listed but stays blank, restart Hyprland or the machine
 - **Enable this Display** turns a screen off. On a non-primary GPU that can leave the panel blank until Hyprland or a reboot; Detect still finds it
-- Pick a screen, then set **resolution**, **refresh**, **HDR**, **VRR**, **scale**, **orientation**, or **mirror**
+- Pick a screen, then set **resolution**, **refresh**, **HDR**, **VRR**, **scale**, **orientation**, or **mirror**. If the panel is taller than the screen (2× scale on 1080p), it scrolls so every control stays reachable
+- **Tune** next to HDR picks 8-bit or 10-bit, HDR PQ vs EDID primaries, and the black-floor / SDR-peak nits. Screens reads 8-bit vs 10-bit from the EDID when it can; otherwise it defaults to 10-bit and you can switch
+- Laptop built-in panels are written as `eDP-1` / `LVDS` / `DSI` so Omarchy's clamshell helper keeps your scale instead of forcing 2
 - **Save** names the current layout. Click the profile name (or **Apply**) to write it. Two or more profiles become a dropdown. **On connect** reapplies a matching profile when a display is plugged in
 - Turning a display on, or turning **Mirror** off, restores the matching saved layout instead of leaving tiles stacked
 - Labels use Hyprland's model string. HDR and VRR disable themselves when that panel cannot do them
@@ -90,7 +92,7 @@ Your last `monitors.lua` stays in place. Backups and profiles are not deleted.
 - Hyprland 0.55+ Lua monitor config (`hl.monitor`)
 - `python3` and `jq` (already on Omarchy)
 
-HDR is 10-bit PQ (`cm = hdr`, `bitdepth = 10`). Some capture tools do not like 10-bit. VRR is Hyprland's four modes: Off, Always, Fullscreen, and Games & video. Always + HDR can flicker on some OLEDs; Fullscreen or Games & video is the usual workaround.
+Hyprland HDR is PQ (`cm = hdr` or `hdredid`) at **8-bit or 10-bit**. There is no HLG preset. Screens prefers 10-bit when the EDID advertises deep color, and 8-bit when an HDMI VSDB is present without it. **Tune** can override that, and sets SDR black to 0.005 nits (Hyprland's stock 0.2 nits is the lifted-black glow). Some capture tools do not like 10-bit. VRR is Hyprland's four modes: Off, Always, Fullscreen, and Games & video. Always + HDR can flicker on some OLEDs; Fullscreen or Games & video is the usual workaround.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd omarchy-screens
 - Labels use Hyprland's model string. HDR and VRR disable themselves when that panel cannot do them
 - **Make primary** chooses which screen the panel prefers when it opens
 
-Changes write `~/.config/hypr/monitors.lua` after you drag, turn a display on, or save. Backups and profiles land in `~/.local/state/im0001gt.screens/`. Stock Omarchy monitor files are replaced; other custom files keep their text and get a managed block appended.
+Changes write `~/.config/hypr/monitors.lua` after you drag, turn a display on, or save. The **first** time Screens sees your `monitors.lua` (install or first panel open, before it writes), it copies that file to `~/.local/state/im0001gt.screens/original-monitors.lua` and never overwrites it. Later applies keep a short rolling set of timestamped copies in the same folder. Stock Omarchy monitor files are replaced; other custom files keep their text and get a managed block appended.
 
 Move it with `omarchy bar move im0001gt.screens`.
 
@@ -84,7 +84,20 @@ omarchy restart shell
 omarchy plugin remove im0001gt.screens
 ```
 
-Your last `monitors.lua` stays in place. Backups and profiles are not deleted.
+Removing the plugin does **not** put `monitors.lua` back. The last layout Screens wrote stays in `~/.config/hypr/monitors.lua`. The first-install copy and profiles stay in `~/.local/state/im0001gt.screens/` on purpose.
+
+To go back to the layout from before Screens:
+
+```bash
+~/.config/omarchy/plugins/im0001gt.screens/scripts/display-ctl restore-original
+```
+
+If you already removed the plugin, copy the snapshot yourself:
+
+```bash
+cp ~/.local/state/im0001gt.screens/original-monitors.lua ~/.config/hypr/monitors.lua
+hyprctl reload
+```
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Screens
 
-An Omarchy bar widget that treats the desk as a layout, not a list of percentages.
+An Omarchy bar widget for arranging displays and setting how they look.
 
-Click the two-tile mark for a panel that stays open. Displays are drawn at their real Hyprland size. Drag them and they **snap flush** — no overlapping tiles, no cursor-eating gaps. Then set refresh, HDR, VRR, scale, rotation, and mirroring on the selected screen. Save the desk as a named **profile**; Screens can restore it when a display is plugged in.
-
-Stock **Display** stays put (brightness and text size). Screens uses a different icon on purpose.
+Click the two-tile mark for a panel that stays open. Displays are drawn at their real Hyprland size. Drag them and they **snap flush** — no overlapping tiles, no cursor-eating gaps. Then set brightness, text size, resolution, refresh, HDR, VRR, scale, rotation, and mirroring. Save the desk as a named **profile**; Screens can restore it when a display is plugged in.
 
 <p align="center">
-  <img width="497" height="761" alt="image" src="https://github.com/user-attachments/assets/94012df0-bf3a-4e7d-bfcc-08cee6dfcb16" />
+  <img width="497" height="761" alt="Screens panel" src="https://github.com/user-attachments/assets/94012df0-bf3a-4e7d-bfcc-08cee6dfcb16" />
 </p>
 
-| Click | Drag | Per screen | Profiles |
+| Layout | This screen | HDR | Profiles |
 | --- | --- | --- | --- |
-| Open the panel | Snap tiles to neighboring edges | Resolution, Hz, HDR, four VRR modes, scale, rotation, mirror, Detect | Name a desk, restore it on connect |
+| Drag tiles; edges snap | Brightness, text size, resolution, Hz, scale, rotation, mirror, Detect | 8-bit or 10-bit PQ, Tune for black / peak | Name a desk; restore on connect |
 
-Works with two screens or a full battlestation. A fallback Hyprland rule still catches anything you hot-plug later.
+Works with two screens or a full battlestation. A fallback Hyprland rule still catches anything you hot-plug later. The panel scrolls when it is taller than the screen, so controls stay reachable at large scale (for example 2× on 1080p).
+
+Stock **Display** can stay on the bar if you want it. Screens uses a different icon on purpose.
 
 ## Why this exists
 
@@ -26,7 +26,7 @@ Other listed tools cover adjacent jobs:
 - **hyprmoncfg** — named profiles and a hotplug daemon, via an external TUI the bar only launches
 - **Generic layout editors** — often reuse the stock monitor glyph, skip snap, and leave HDR/VRR in `monitors.lua`
 
-Screens is the other thing: the editor lives in the bar, follows the theme, and writes Hyprland Lua only after you act. No AUR package. No extra daemon.
+Screens keeps the editor in the bar, follows the theme, and writes Hyprland Lua only after you act. No AUR package. No extra daemon.
 
 ## Install
 
@@ -46,22 +46,41 @@ cd omarchy-screens
 ./install.sh
 ```
 
+The first time Screens sees `~/.config/hypr/monitors.lua`, it copies that file to `~/.local/state/im0001gt.screens/original-monitors.lua` and never overwrites it.
+
 ## Use
+
+**Layout**
 
 - **Click** the two-tile icon — the panel stays open until you click away
 - **Drag** a tile — edges snap so the cursor never falls in a gap
 - **Find** — badge on the *selected* output (not only the screen that holds the menu)
 - **Detect** — rescan Hyprland and DRM for a plugged-in screen that is currently off, then **Turn on**. If it is listed but stays blank, restart Hyprland or the machine
 - **Enable this Display** turns a screen off. On a non-primary GPU that can leave the panel blank until Hyprland or a reboot; Detect still finds it
-- Pick a screen, then set **resolution**, **refresh**, **HDR**, **VRR**, **scale**, **orientation**, or **mirror**. If the panel is taller than the screen (2× scale on 1080p), it scrolls so every control stays reachable
-- **Tune** next to HDR picks 8-bit or 10-bit, HDR PQ vs EDID primaries, and the black-floor / SDR-peak nits. Screens reads 8-bit vs 10-bit from the EDID when it can; otherwise it defaults to 10-bit and you can switch
-- Laptop built-in panels are written as `eDP-1` / `LVDS` / `DSI` so Omarchy's clamshell helper keeps your scale instead of forcing 2
-- **Save** names the current layout. Click the profile name (or **Apply**) to write it. Two or more profiles become a dropdown. **On connect** reapplies a matching profile when a display is plugged in
-- Turning a display on, or turning **Mirror** off, restores the matching saved layout instead of leaving tiles stacked
-- Labels use Hyprland's model string. HDR and VRR disable themselves when that panel cannot do them
 - **Make primary** chooses which screen the panel prefers when it opens
 
-Changes write `~/.config/hypr/monitors.lua` after you drag, turn a display on, or save. The **first** time Screens sees your `monitors.lua` (install or first panel open, before it writes), it copies that file to `~/.local/state/im0001gt.screens/original-monitors.lua` and never overwrites it. Later applies keep a short rolling set of timestamped copies in the same folder. Stock Omarchy monitor files are replaced; other custom files keep their text and get a managed block appended.
+**This screen**
+
+- Pick a screen, then set **brightness**, **text size**, **resolution**, **refresh**, **scale**, **orientation**, or **mirror**
+- Brightness follows the selected output (internal backlight or DDC). It hides when that output has no backlight. A short label (Night owl, Golden hour, and so on) shows in the panel header while you drag the slider
+- Text size uses Omarchy's 9–20 px stops and applies to the shell, GTK, and terminals
+- Laptop built-in panels are written as `eDP-1` / `LVDS` / `DSI` so Omarchy's clamshell helper keeps your scale instead of forcing 2
+- Labels use Hyprland's model string
+
+**HDR and VRR**
+
+- **HDR** enables PQ output. **Tune** picks 8-bit or 10-bit, HDR PQ vs EDID primaries, black floor, and SDR peak
+- Screens reads 8-bit vs 10-bit from the EDID when it can; otherwise it defaults to 10-bit. Enabling HDR sets black floor to 0.005 nits (Hyprland's default 0.2 nits lifts dark scenes)
+- HDR and VRR disable themselves when that panel cannot do them
+- VRR modes: Off, Always, Fullscreen, Games & video. Always + HDR can flicker on some OLEDs; Fullscreen or Games & video is the usual workaround
+
+**Profiles**
+
+- **Save** names the current layout. Click the profile name (or **Apply**) to write it. Two or more profiles become a dropdown
+- **On connect** reapplies a matching profile when a display is plugged in
+- Turning a display on, or turning **Mirror** off, restores the matching saved layout instead of leaving tiles stacked
+
+Changes write `~/.config/hypr/monitors.lua` after you drag, turn a display on, or save. Later applies keep a short rolling set of timestamped copies in `~/.local/state/im0001gt.screens/`. Stock Omarchy monitor files are replaced; other custom files keep their text and get a managed block appended.
 
 Move it with `omarchy bar move im0001gt.screens`.
 
@@ -84,15 +103,15 @@ omarchy restart shell
 omarchy plugin remove im0001gt.screens
 ```
 
-Removing the plugin does **not** put `monitors.lua` back. The last layout Screens wrote stays in `~/.config/hypr/monitors.lua`. The first-install copy and profiles stay in `~/.local/state/im0001gt.screens/` on purpose.
+Removing the plugin does not restore `monitors.lua`. The last layout Screens wrote stays in `~/.config/hypr/monitors.lua`. The first-install copy and profiles stay in `~/.local/state/im0001gt.screens/`.
 
-To go back to the layout from before Screens:
+To restore the layout from before Screens:
 
 ```bash
 ~/.config/omarchy/plugins/im0001gt.screens/scripts/display-ctl restore-original
 ```
 
-If you already removed the plugin, copy the snapshot yourself:
+If you already removed the plugin:
 
 ```bash
 cp ~/.local/state/im0001gt.screens/original-monitors.lua ~/.config/hypr/monitors.lua
@@ -105,7 +124,7 @@ hyprctl reload
 - Hyprland 0.55+ Lua monitor config (`hl.monitor`)
 - `python3` and `jq` (already on Omarchy)
 
-Hyprland HDR is PQ (`cm = hdr` or `hdredid`) at **8-bit or 10-bit**. There is no HLG preset. Screens prefers 10-bit when the EDID advertises deep color, and 8-bit when an HDMI VSDB is present without it. **Tune** can override that, and sets SDR black to 0.005 nits (Hyprland's stock 0.2 nits is the lifted-black glow). Some capture tools do not like 10-bit. VRR is Hyprland's four modes: Off, Always, Fullscreen, and Games & video. Always + HDR can flicker on some OLEDs; Fullscreen or Games & video is the usual workaround.
+Hyprland HDR is PQ (`cm = hdr` or `hdredid`) at 8-bit or 10-bit. There is no HLG preset. Some capture tools do not like 10-bit.
 
 ## Layout
 

--- a/Screens.qml
+++ b/Screens.qml
@@ -45,6 +45,7 @@ Panel {
   property var standbyNames: []
   property bool hybridGpus: false
   property bool showHybridNotice: false
+  property bool hdrTuning: false
 
   readonly property var selected: {
     if (selectedIndex < 0 || selectedIndex >= monitors.length) return null
@@ -70,6 +71,14 @@ Panel {
     { value: "1", label: "Always" },
     { value: "2", label: "Fullscreen" },
     { value: "3", label: "Games & video" }
+  ]
+  readonly property var bitdepthOptions: [
+    { value: "8", label: "8-bit" },
+    { value: "10", label: "10-bit" }
+  ]
+  readonly property var hdrCmOptions: [
+    { value: "hdr", label: "HDR PQ" },
+    { value: "hdredid", label: "HDR EDID" }
   ]
   readonly property string barScreenName: {
     var win = button.QsWindow ? button.QsWindow.window : null
@@ -183,6 +192,7 @@ Panel {
 
   function setScale(scale) {
     mutateSelected(function(m) { m.scale = Number(scale) })
+    Qt.callLater(function() { root.revealItem(scaleSection) })
   }
 
   function setTransform(value) {
@@ -199,7 +209,66 @@ Panel {
 
   function setHdr(on) {
     if (!root.selectedHdrOk) return
-    mutateSelected(function(m) { m.hdr = !!on })
+    mutateSelected(function(m) {
+      m.hdr = !!on
+      if (!on) return
+      var capable = Number(m.bitdepthCapable) === 8 ? 8 : 10
+      if (Number(m.bitdepth) !== 8 && Number(m.bitdepth) !== 10)
+        m.bitdepth = capable
+      if (m.cm !== "hdr" && m.cm !== "hdredid") m.cm = "hdr"
+      // Hyprland's 0.2 nits SDR black floor is the IPS-like glow. 0.005 is
+      // the wiki's true-black mapping; keep a user-tuned value if present.
+      if (m.sdrMinLuminance === undefined || m.sdrMinLuminance === null
+          || Number(m.sdrMinLuminance) >= 0.199)
+        m.sdrMinLuminance = 0.005
+      if (!m.sdrMaxLuminance || Number(m.sdrMaxLuminance) <= 80)
+        m.sdrMaxLuminance = Model.defaultSdrPeak(m)
+      if (m.minLuminance === undefined || Number(m.minLuminance) < 0)
+        m.minLuminance = 0
+    })
+    if (on) Qt.callLater(function() { root.revealItem(hdrTuneSection.visible ? hdrTuneSection : hdrRow) })
+  }
+
+  function setBitdepth(value) {
+    if (!root.selectedHdrOk) return
+    var n = parseInt(value, 10) === 8 ? 8 : 10
+    mutateSelected(function(m) { m.bitdepth = n })
+  }
+
+  function setHdrCm(value) {
+    if (!root.selectedHdrOk) return
+    var cm = String(value) === "hdredid" ? "hdredid" : "hdr"
+    mutateSelected(function(m) { m.cm = cm })
+  }
+
+  function setSdrMin(value, apply) {
+    if (!root.selected) return
+    var next = Model.clone(root.monitors)
+    next[root.selectedIndex].sdrMinLuminance = Math.max(0, Math.min(0.2, Number(value)))
+    root.monitors = next
+    if (apply) applyNow()
+  }
+
+  function setSdrMax(value, apply) {
+    if (!root.selected) return
+    var next = Model.clone(root.monitors)
+    next[root.selectedIndex].sdrMaxLuminance = Math.max(40, Math.min(400, Math.round(Number(value))))
+    root.monitors = next
+    if (apply) applyNow()
+  }
+
+  function revealItem(item) {
+    if (!item || !panelFlick) return
+    if (panelFlick.contentHeight <= panelFlick.height) return
+    var y = item.mapToItem(panelFlick.contentItem, 0, 0).y
+    var h = item.height
+    var top = panelFlick.contentY
+    var bot = top + panelFlick.height
+    var margin = Style.space(8)
+    if (y < top + margin)
+      panelFlick.contentY = Math.max(0, y - margin)
+    else if (y + h > bot - margin)
+      panelFlick.contentY = Math.max(0, Math.min(panelFlick.contentHeight - panelFlick.height, y + h + margin - panelFlick.height))
   }
 
   function setEnabled(on) {
@@ -363,6 +432,7 @@ Panel {
     if (!opened) {
       root.detectNote = ""
       root.detectPending = false
+      root.hdrTuning = false
       return
     }
     root.userPicked = false
@@ -476,13 +546,27 @@ Panel {
       anchors.fill: parent
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
+      onMoveRequested: function(dx, dy) {
+        if (!panelFlick.interactive) return
+        var step = Style.space(48)
+        var maxY = Math.max(0, panelFlick.contentHeight - panelFlick.height)
+        panelFlick.contentY = Math.max(0, Math.min(maxY, panelFlick.contentY + dy * step))
+      }
 
-      Column {
-        id: panelColumn
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        spacing: Style.space(10)
+      Flickable {
+        id: panelFlick
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: panelColumn.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        flickableDirection: Flickable.VerticalFlick
+        interactive: contentHeight > height && !root.dragging
+
+        Column {
+          id: panelColumn
+          width: panelFlick.width
+          spacing: Style.space(10)
 
           Item {
             width: parent.width
@@ -1013,6 +1097,7 @@ Panel {
             }
 
             Column {
+              id: scaleSection
               width: parent.width
               spacing: Style.space(4)
 
@@ -1074,15 +1159,244 @@ Panel {
               }
             }
 
-            Toggle {
-              visible: root.selectedHdrOk
+            Column {
+              id: hdrRow
               width: parent.width
-              label: "HDR"
-              description: "10-bit PQ"
-              checked: !!(root.selected && root.selected.hdr)
-              foreground: root.bar.foreground
-              fontFamily: root.bar.fontFamily
-              onClicked: root.setHdr(!(root.selected && root.selected.hdr))
+              spacing: Style.space(6)
+              visible: root.selectedHdrOk
+
+              Row {
+                width: parent.width
+                spacing: Style.space(8)
+
+                Toggle {
+                  width: parent.width - tuneBtn.width - parent.spacing
+                  label: "HDR"
+                  description: Model.hdrDescription(root.selected)
+                  checked: !!(root.selected && root.selected.hdr)
+                  foreground: root.bar.foreground
+                  fontFamily: root.bar.fontFamily
+                  onClicked: root.setHdr(!(root.selected && root.selected.hdr))
+                }
+
+                Button {
+                  id: tuneBtn
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: root.hdrTuning ? "Done" : "Tune"
+                  fontSize: Style.font.caption
+                  fontFamily: root.bar.fontFamily
+                  foreground: root.bar.foreground
+                  bordered: true
+                  active: root.hdrTuning
+                  horizontalPadding: Style.space(10)
+                  verticalPadding: Style.space(4)
+                  tooltipText: "8-bit / 10-bit, primaries, and black / peak brightness"
+                  onClicked: {
+                    root.hdrTuning = !root.hdrTuning
+                    if (root.hdrTuning)
+                      Qt.callLater(function() { root.revealItem(hdrTuneSection) })
+                  }
+                }
+              }
+
+              Column {
+                id: hdrTuneSection
+                width: parent.width
+                spacing: Style.space(8)
+                visible: root.hdrTuning
+
+                Column {
+                  width: parent.width
+                  spacing: Style.space(4)
+
+                  PanelSectionHeader {
+                    text: "BIT DEPTH"
+                    foreground: root.bar.foreground
+                    fontFamily: root.bar.fontFamily
+                  }
+
+                  Grid {
+                    id: bitdepthRow
+                    width: parent.width
+                    columns: root.bitdepthOptions.length
+                    spacing: Style.spacing.xs
+                    readonly property real cellWidth: (width - spacing * (columns - 1)) / columns
+
+                    Repeater {
+                      model: root.bitdepthOptions
+
+                      Button {
+                        required property var modelData
+                        width: bitdepthRow.cellWidth
+                        text: modelData.label
+                        fontSize: Style.font.caption
+                        fontFamily: root.bar.fontFamily
+                        foreground: root.bar.foreground
+                        bordered: true
+                        active: root.selected && Number(root.selected.bitdepth) === Number(modelData.value)
+                        onClicked: root.setBitdepth(modelData.value)
+                      }
+                    }
+                  }
+
+                  Text {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    text: Number(root.selected && root.selected.bitdepthCapable) === 8
+                      ? "This EDID looks 8-bit. 10-bit may still work over DP, or break capture."
+                      : "10-bit is the usual HDR output. Switch to 8-bit if capture tools go black."
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+
+                Column {
+                  width: parent.width
+                  spacing: Style.space(4)
+
+                  PanelSectionHeader {
+                    text: "PRIMARIES"
+                    foreground: root.bar.foreground
+                    fontFamily: root.bar.fontFamily
+                  }
+
+                  Grid {
+                    id: hdrCmRow
+                    width: parent.width
+                    columns: root.hdrCmOptions.length
+                    spacing: Style.spacing.xs
+                    readonly property real cellWidth: (width - spacing * (columns - 1)) / columns
+
+                    Repeater {
+                      model: root.hdrCmOptions
+
+                      Button {
+                        required property var modelData
+                        width: hdrCmRow.cellWidth
+                        text: modelData.label
+                        fontSize: Style.font.caption
+                        fontFamily: root.bar.fontFamily
+                        foreground: root.bar.foreground
+                        bordered: true
+                        active: root.selected && String(root.selected.cm) === String(modelData.value)
+                        onClicked: root.setHdrCm(modelData.value)
+                      }
+                    }
+                  }
+                }
+
+                Column {
+                  width: parent.width
+                  spacing: Style.space(4)
+
+                  Item {
+                    width: parent.width
+                    implicitHeight: Math.max(blackHeader.implicitHeight, blackValue.implicitHeight)
+
+                    PanelSectionHeader {
+                      id: blackHeader
+                      text: "BLACK FLOOR"
+                      foreground: root.bar.foreground
+                      fontFamily: root.bar.fontFamily
+                      anchors.left: parent.left
+                      anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                      id: blackValue
+                      text: {
+                        var n = root.selected ? Number(root.selected.sdrMinLuminance) : 0.005
+                        if (!isFinite(n)) n = 0.005
+                        return n.toFixed(3) + " nits"
+                      }
+                      color: Qt.darker(root.bar.foreground, 1.4)
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: true
+                      anchors.right: parent.right
+                      anchors.verticalCenter: parent.verticalCenter
+                    }
+                  }
+
+                  PanelSlider {
+                    width: parent.width
+                    bar: root.bar
+                    minimum: 0
+                    maximum: 0.2
+                    step: 0.005
+                    value: root.selected && isFinite(Number(root.selected.sdrMinLuminance))
+                      ? Number(root.selected.sdrMinLuminance) : 0.005
+                    onMoved: function(v) { root.setSdrMin(v, false) }
+                    onReleased: function(v) { root.setSdrMin(v, true) }
+                  }
+
+                  Text {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    text: "Lower is true black. Hyprland defaults to 0.200, which lifts dark scenes."
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+
+                Column {
+                  width: parent.width
+                  spacing: Style.space(4)
+
+                  Item {
+                    width: parent.width
+                    implicitHeight: Math.max(peakHeader.implicitHeight, peakValue.implicitHeight)
+
+                    PanelSectionHeader {
+                      id: peakHeader
+                      text: "SDR PEAK"
+                      foreground: root.bar.foreground
+                      fontFamily: root.bar.fontFamily
+                      anchors.left: parent.left
+                      anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                      id: peakValue
+                      text: {
+                        var n = root.selected ? Number(root.selected.sdrMaxLuminance) : 200
+                        if (!isFinite(n)) n = 200
+                        return Math.round(n) + " nits"
+                      }
+                      color: Qt.darker(root.bar.foreground, 1.4)
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: true
+                      anchors.right: parent.right
+                      anchors.verticalCenter: parent.verticalCenter
+                    }
+                  }
+
+                  PanelSlider {
+                    width: parent.width
+                    bar: root.bar
+                    minimum: 80
+                    maximum: 400
+                    step: 10
+                    integer: true
+                    value: root.selected && isFinite(Number(root.selected.sdrMaxLuminance))
+                      ? Number(root.selected.sdrMaxLuminance) : 200
+                    onMoved: function(v) { root.setSdrMax(v, false) }
+                    onReleased: function(v) { root.setSdrMax(v, true) }
+                  }
+
+                  Text {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    text: "SDR content in HDR mode. 200–250 is typical; 80 is Hyprland's stock peak."
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+              }
             }
 
             Dropdown {
@@ -1154,6 +1468,7 @@ Panel {
           Item { width: parent.width; height: Style.space(8) }
         }
       }
+    }
     }
 
   PanelWindow {

--- a/Screens.qml
+++ b/Screens.qml
@@ -46,6 +46,13 @@ Panel {
   property bool hybridGpus: false
   property bool showHybridNotice: false
   property bool hdrTuning: false
+  property int brightnessPercent: 0
+  property int pendingBrightnessPercent: 0
+  property bool brightnessSetQueued: false
+  property bool brightnessAvailable: false
+  property int textSizePreviewIndex: -1
+  property bool reflowingText: false
+  readonly property var textSizeStops: [9, 10, 11, 12, 14, 16, 20]
 
   readonly property var selected: {
     if (selectedIndex < 0 || selectedIndex >= monitors.length) return null
@@ -105,6 +112,77 @@ Panel {
 
   function refresh() {
     if (!stateProc.running) stateProc.running = true
+    if (root.opened) root.refreshBrightness()
+  }
+
+  function brightnessMonitor() {
+    if (root.selected && root.selected.name) return String(root.selected.name)
+    return root.barScreenName
+  }
+
+  function refreshBrightness() {
+    if (setBrightnessProc.running) return
+    if (brightnessSlider && brightnessSlider.dragging) return
+    var name = root.brightnessMonitor()
+    if (!name) {
+      root.brightnessAvailable = false
+      return
+    }
+    brightnessProc.command = ["omarchy-brightness-display", "--monitor", name]
+    if (!brightnessProc.running) brightnessProc.running = true
+  }
+
+  function setBrightness(value) {
+    var percent = Model.clampBrightness(value)
+    root.brightnessPercent = percent
+    root.pendingBrightnessPercent = percent
+    var name = root.brightnessMonitor()
+    if (!name) return
+    if (setBrightnessProc.running) {
+      root.brightnessSetQueued = true
+      return
+    }
+    root.brightnessSetQueued = false
+    setBrightnessProc.command = ["omarchy-brightness-display", "--no-osd", "--monitor", name, percent + "%"]
+    setBrightnessProc.running = true
+  }
+
+  function previewBrightness(value) {
+    root.brightnessPercent = Model.clampBrightness(value)
+    brightnessDebounce.restart()
+  }
+
+  function nearestTextStop(px) {
+    var best = 0
+    var bestDist = 1e9
+    for (var i = 0; i < root.textSizeStops.length; i++) {
+      var d = Math.abs(root.textSizeStops[i] - px)
+      if (d < bestDist) { bestDist = d; best = i }
+    }
+    return best
+  }
+
+  function currentTextIndex() {
+    return root.textSizePreviewIndex >= 0
+      ? root.textSizePreviewIndex
+      : root.nearestTextStop(Style.font.baseSize)
+  }
+
+  function displayedTextPx() {
+    return root.textSizePreviewIndex >= 0
+      ? root.textSizeStops[root.textSizePreviewIndex]
+      : Style.font.baseSize
+  }
+
+  function setTextSize(px) {
+    root.textSizePreviewIndex = root.nearestTextStop(px)
+    textScaleProc.command = ["omarchy-display-text-size", String(px)]
+    if (!textScaleProc.running) textScaleProc.running = true
+  }
+
+  function markReflowing() {
+    root.reflowingText = true
+    reflowSettle.restart()
   }
 
   function adopt(data) {
@@ -216,8 +294,7 @@ Panel {
       if (Number(m.bitdepth) !== 8 && Number(m.bitdepth) !== 10)
         m.bitdepth = capable
       if (m.cm !== "hdr" && m.cm !== "hdredid") m.cm = "hdr"
-      // Hyprland's 0.2 nits SDR black floor is the IPS-like glow. 0.005 is
-      // the wiki's true-black mapping; keep a user-tuned value if present.
+      // Hyprland default sdr_min_luminance is 0.2; 0.005 maps SDR black to the panel.
       if (m.sdrMinLuminance === undefined || m.sdrMinLuminance === null
           || Number(m.sdrMinLuminance) >= 0.199)
         m.sdrMinLuminance = 0.005
@@ -439,6 +516,8 @@ Panel {
     refresh()
   }
 
+  onSelectedIndexChanged: if (root.opened) root.refreshBrightness()
+
   IpcHandler {
     enabled: root.isFocusedBar
     target: "im0001gt.screens"
@@ -513,6 +592,58 @@ Panel {
         try { root.adopt(JSON.parse(text)) }
         catch (e) { root.refresh() }
       }
+    }
+  }
+
+  Process {
+    id: brightnessProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        if (brightnessSlider && brightnessSlider.dragging) return
+        var line = String(text || "").trim().split("\n")[0]
+        var n = parseInt(line, 10)
+        root.brightnessAvailable = line !== "" && line !== "unavailable" && isFinite(n)
+        if (root.brightnessAvailable) root.brightnessPercent = Math.max(0, Math.min(100, n))
+      }
+    }
+  }
+
+  Timer {
+    id: brightnessDebounce
+    interval: 180
+    repeat: false
+    onTriggered: root.setBrightness(root.brightnessPercent)
+  }
+
+  Process {
+    id: setBrightnessProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      if (root.brightnessSetQueued) root.setBrightness(root.pendingBrightnessPercent)
+    }
+  }
+
+  Process {
+    id: textScaleProc
+    stdout: StdioCollector { waitForEnd: true }
+  }
+
+  Timer {
+    id: reflowSettle
+    interval: 300
+    repeat: false
+    onTriggered: root.reflowingText = false
+  }
+
+  Connections {
+    target: Style
+    function onFontBaseSizeChanged() {
+      root.markReflowing()
+      if (root.textSizePreviewIndex >= 0
+          && root.nearestTextStop(Style.font.baseSize) === root.textSizePreviewIndex)
+        root.textSizePreviewIndex = -1
     }
   }
 
@@ -602,6 +733,8 @@ Panel {
 
               Text {
                 text: (root.dragging ? "Snapping edges"
+                  : (brightnessSlider && brightnessSlider.dragging)
+                    ? Model.brightnessName(brightnessSlider.liveValue)
                   : root.detectNote ? root.detectNote
                   : Model.heroStatus(root.selected, root.activeProfile)).toUpperCase()
                 color: Qt.darker(root.bar.foreground, 1.4)
@@ -1097,6 +1230,98 @@ Panel {
             }
 
             Column {
+              visible: root.brightnessAvailable
+              width: parent.width
+              spacing: Style.space(6)
+
+              Item {
+                width: parent.width
+                implicitHeight: Math.max(brightnessHeader.implicitHeight, brightnessPercentLabel.implicitHeight)
+
+                PanelSectionHeader {
+                  id: brightnessHeader
+                  text: "BRIGHTNESS"
+                  foreground: root.bar.foreground
+                  fontFamily: root.bar.fontFamily
+                  anchors.left: parent.left
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Text {
+                  id: brightnessPercentLabel
+                  text: Math.round(brightnessSlider.dragging ? brightnessSlider.liveValue : root.brightnessPercent) + "%"
+                  color: Qt.darker(root.bar.foreground, 1.4)
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: true
+                  anchors.right: parent.right
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+              }
+
+              PanelSlider {
+                id: brightnessSlider
+                width: parent.width
+                bar: root.bar
+                minimum: 1
+                maximum: 100
+                step: 1
+                value: root.brightnessPercent
+                integer: true
+                onMoved: function(v) { root.previewBrightness(v) }
+                onReleased: function(v) {
+                  brightnessDebounce.stop()
+                  root.setBrightness(v)
+                }
+              }
+            }
+
+            Column {
+              width: parent.width
+              spacing: Style.space(6)
+
+              Item {
+                width: parent.width
+                implicitHeight: Math.max(textSizeHeader.implicitHeight, textSizePx.implicitHeight)
+
+                PanelSectionHeader {
+                  id: textSizeHeader
+                  text: "TEXT SIZE"
+                  foreground: root.bar.foreground
+                  fontFamily: root.bar.fontFamily
+                  anchors.left: parent.left
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Text {
+                  id: textSizePx
+                  text: (textSizeSlider.dragging
+                    ? root.textSizeStops[Math.round(textSizeSlider.liveValue)]
+                    : root.displayedTextPx()) + "px"
+                  color: Qt.darker(root.bar.foreground, 1.4)
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: true
+                  anchors.right: parent.right
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+              }
+
+              PanelSlider {
+                id: textSizeSlider
+                width: parent.width
+                bar: root.bar
+                minimum: 0
+                maximum: root.textSizeStops.length - 1
+                step: 1
+                integer: true
+                tickCount: root.textSizeStops.length
+                value: root.currentTextIndex()
+                onReleased: function(v) { root.setTextSize(root.textSizeStops[Math.round(v)]) }
+              }
+            }
+
+            Column {
               id: scaleSection
               width: parent.width
               spacing: Style.space(4)
@@ -1243,8 +1468,8 @@ Panel {
                     width: parent.width
                     wrapMode: Text.WordWrap
                     text: Number(root.selected && root.selected.bitdepthCapable) === 8
-                      ? "This EDID looks 8-bit. 10-bit may still work over DP, or break capture."
-                      : "10-bit is the usual HDR output. Switch to 8-bit if capture tools go black."
+                      ? "EDID reports 8-bit. 10-bit may still work on DisplayPort."
+                      : "10-bit HDR. Use 8-bit if screen capture fails."
                     color: Qt.darker(root.bar.foreground, 1.4)
                     font.family: root.bar.fontFamily
                     font.pixelSize: Style.font.caption
@@ -1334,7 +1559,7 @@ Panel {
                   Text {
                     width: parent.width
                     wrapMode: Text.WordWrap
-                    text: "Lower is true black. Hyprland defaults to 0.200, which lifts dark scenes."
+                    text: "Lower maps SDR black closer to the panel. Enabling HDR sets 0.005 nits."
                     color: Qt.darker(root.bar.foreground, 1.4)
                     font.family: root.bar.fontFamily
                     font.pixelSize: Style.font.caption
@@ -1390,7 +1615,7 @@ Panel {
                   Text {
                     width: parent.width
                     wrapMode: Text.WordWrap
-                    text: "SDR content in HDR mode. 200–250 is typical; 80 is Hyprland's stock peak."
+                    text: "SDR white level while HDR is on. Typical range 200–250 nits."
                     color: Qt.darker(root.bar.foreground, 1.4)
                     font.family: root.bar.fontFamily
                     font.pixelSize: Style.font.caption

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,14 @@ else
   copy_plugin_files
 fi
 
+# Snapshot ~/.config/hypr/monitors.lua once, before Screens ever writes it.
+# Survives plugin remove. Restore with: display-ctl restore-original
+ctl="$plugin_dir/scripts/display-ctl"
+[[ -x $ctl ]] || ctl="$SCRIPT_DIR/scripts/display-ctl"
+if [[ -x $ctl ]] && run_as_user "$ctl" backup-original >/dev/null; then
+  echo "Kept your current monitors.lua at ~/.local/state/im0001gt.screens/original-monitors.lua"
+fi
+
 run_as_user omarchy-shell shell rescanPlugins >/dev/null 2>&1 || true
 
 discovered=0
@@ -125,3 +133,5 @@ echo "Done. Screens is a bar widget — click the two-tile icon."
 echo "  Drag tiles to arrange. They snap flush."
 echo "  Per screen: resolution, refresh, HDR, VRR, scale, rotation."
 echo "  Uninstall: omarchy plugin remove $PLUGIN_ID"
+echo "  Restore the monitors.lua from before Screens:"
+echo "    $plugin_dir/scripts/display-ctl restore-original"

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,8 @@ reload_shell
 echo
 echo "Done. Screens is a bar widget — click the two-tile icon."
 echo "  Drag tiles to arrange. They snap flush."
-echo "  Per screen: resolution, refresh, HDR, VRR, scale, rotation."
+echo "  Per screen: brightness, resolution, refresh, HDR, VRR, scale, rotation."
+echo "  Desktop: text size."
 echo "  Uninstall: omarchy plugin remove $PLUGIN_ID"
-echo "  Restore the monitors.lua from before Screens:"
+echo "  Restore pre-Screens monitors.lua:"
 echo "    $plugin_dir/scripts/display-ctl restore-original"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "im0001gt.screens",
   "name": "Screens",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "author": "IM0001GT",
   "license": "MIT",
   "homepage": "https://github.com/IM0001GT/omarchy-screens",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "author": "IM0001GT",
   "license": "MIT",
   "homepage": "https://github.com/IM0001GT/omarchy-screens",
-  "description": "Snap-to-edge monitor layout with HDR, VRR, refresh, and hardware-aware profiles that apply on hotplug",
+  "description": "Snap-to-edge monitor layout with brightness, text size, HDR, VRR, and hardware-aware profiles that apply on hotplug",
   "kinds": [
     "bar-widget"
   ],
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Screens",
-    "description": "Arrange monitors with snap, then set refresh, HDR, and VRR in the bar. Profiles restore on hotplug.",
+    "description": "Arrange monitors with snap, then set brightness, text size, refresh, HDR, and VRR. Profiles restore on hotplug.",
     "category": "Hardware",
     "defaultSection": "right",
     "allowMultiple": false

--- a/scripts/display-ctl
+++ b/scripts/display-ctl
@@ -13,6 +13,8 @@ Commands:
   profile auto 0|1
   profile primary <identity>
   idle off|on|notice
+  backup-original    snapshot monitors.lua once, before Screens writes it
+  restore-original   put that first snapshot back and reload Hyprland
 """
 
 from __future__ import annotations
@@ -29,8 +31,10 @@ import time
 MONITORS_LUA = os.path.expanduser("~/.config/hypr/monitors.lua")
 BACKUP_DIR = os.path.expanduser("~/.local/state/im0001gt.screens")
 PROFILES_PATH = os.path.join(BACKUP_DIR, "profiles.json")
+ORIGINAL_BACKUP = os.path.join(BACKUP_DIR, "original-monitors.lua")
 MANAGED_BEGIN = "-- BEGIN im0001gt.screens"
 MANAGED_END = "-- END im0001gt.screens"
+STAMPED_BACKUP_GLOB = "monitors.lua.[0-9]*"
 
 
 def run(cmd, timeout=4):
@@ -570,6 +574,7 @@ def snapshot():
             if key in rule:
                 entry[key] = rule[key]
     merge_drm_connected(monitors)
+    ensure_original_backup()
     store = load_store()
     ids = [m["identity"] for m in monitors if m.get("identity")]
     match = match_profile(store, ids)
@@ -1053,6 +1058,46 @@ def render_lua(monitors, gdk_scale):
     return "\n".join(lines) + "\n"
 
 
+def looks_managed(text):
+    return MANAGED_BEGIN in (text or "")
+
+
+def read_text(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def write_original_backup(text):
+    os.makedirs(BACKUP_DIR, mode=0o700, exist_ok=True)
+    tmp = ORIGINAL_BACKUP + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    os.replace(tmp, ORIGINAL_BACKUP)
+    return True
+
+
+def ensure_original_backup(text=None):
+    """Keep the first unmanaged monitors.lua forever. Never overwrite it.
+
+    Rolling apply backups are separate and get pruned. This file survives
+    plugin remove so someone can go back to the layout they had before Screens.
+    """
+    if os.path.isfile(ORIGINAL_BACKUP):
+        return False
+    if text is None:
+        text = read_text(MONITORS_LUA) if os.path.isfile(MONITORS_LUA) else ""
+    if text.strip() and not looks_managed(text):
+        return write_original_backup(text)
+    for path in sorted(glob.glob(os.path.join(BACKUP_DIR, STAMPED_BACKUP_GLOB))):
+        body = read_text(path)
+        if body.strip() and not looks_managed(body):
+            return write_original_backup(body)
+    return False
+
+
 def backup_file(path):
     if not os.path.isfile(path):
         return
@@ -1060,12 +1105,24 @@ def backup_file(path):
     stamp = time.strftime("%Y%m%d-%H%M%S")
     dest = os.path.join(BACKUP_DIR, "monitors.lua.%s" % stamp)
     shutil.copy2(path, dest)
-    old = sorted(glob.glob(os.path.join(BACKUP_DIR, "monitors.lua.*")))
+    old = sorted(glob.glob(os.path.join(BACKUP_DIR, STAMPED_BACKUP_GLOB)))
     for extra in old[:-8]:
         try:
             os.unlink(extra)
         except OSError:
             pass
+
+
+def restore_original():
+    if not os.path.isfile(ORIGINAL_BACKUP):
+        print("restore-original: no first-install snapshot at %s" % ORIGINAL_BACKUP, file=sys.stderr)
+        return 2
+    if os.path.isfile(MONITORS_LUA):
+        backup_file(MONITORS_LUA)
+    shutil.copy2(ORIGINAL_BACKUP, MONITORS_LUA)
+    reload_hypr()
+    print("Restored %s from %s" % (MONITORS_LUA, ORIGINAL_BACKUP))
+    return 0
 
 
 def splice_managed(existing, block):
@@ -1102,6 +1159,7 @@ def write_monitors_lua(monitors):
         text = render_lua(monitors, gdk)
     else:
         text = (existing.rstrip() + "\n\n" + block) if existing.strip() else render_lua(monitors, gdk)
+    ensure_original_backup(existing)
     backup_file(MONITORS_LUA)
     os.makedirs(os.path.dirname(MONITORS_LUA), exist_ok=True)
     tmp = MONITORS_LUA + ".tmp"
@@ -1367,6 +1425,17 @@ def main(argv):
     if cmd == "state":
         print(json.dumps(snapshot(), separators=(",", ":")))
         return 0
+    if cmd == "backup-original":
+        if os.path.isfile(ORIGINAL_BACKUP):
+            print(ORIGINAL_BACKUP)
+            return 0
+        if ensure_original_backup():
+            print(ORIGINAL_BACKUP)
+            return 0
+        print("backup-original: no unmanaged monitors.lua to snapshot", file=sys.stderr)
+        return 1
+    if cmd == "restore-original":
+        return restore_original()
     if cmd == "apply":
         raw = argv[1] if len(argv) > 1 else sys.stdin.read()
         try:

--- a/scripts/display-ctl
+++ b/scripts/display-ctl
@@ -111,21 +111,42 @@ def drm_edid_path(name):
     return matches[0] if matches else None
 
 
+def decode_hdr_max_nits(cv):
+    if not cv:
+        return None
+    return int(round(50.0 * (2.0 ** (cv / 32.0))))
+
+
+def decode_hdr_min_nits(cv, max_nits):
+    if not cv or not max_nits:
+        return None
+    return float(max_nits) * ((cv / 255.0) ** 2) / 100.0
+
+
 def edid_caps(name):
     path = drm_edid_path(name)
-    hdr = False
-    vrr = False
+    caps = {
+        "hdr": False,
+        "vrr": False,
+        "bitdepth": 10,
+        "min_luminance": None,
+        "max_luminance": None,
+        "max_avg_luminance": None,
+    }
     if not path:
-        return hdr, vrr
+        return caps
     try:
         data = open(path, "rb").read()
     except OSError:
-        return hdr, vrr
+        return caps
     if len(data) < 128:
-        return hdr, vrr
+        return caps
+
+    hdmi_vsdb = False
+    hdmi_deep = False
 
     def walk(block):
-        nonlocal hdr, vrr
+        nonlocal hdmi_vsdb, hdmi_deep
         if len(block) < 5 or block[0] != 0x02:
             return
         dtd = block[2]
@@ -143,15 +164,35 @@ def edid_caps(name):
                 ext = payload[0]
                 # 6 = HDR static metadata, 7 = HDR dynamic metadata
                 if ext in (6, 7):
-                    hdr = True
-                # 14 = HDMI Forum SCDB (VRR), 1 = video capability
+                    caps["hdr"] = True
+                if ext == 6 and len(payload) >= 4:
+                    mx = decode_hdr_max_nits(payload[3])
+                    if mx:
+                        caps["max_luminance"] = mx
+                    if len(payload) >= 5:
+                        avg = decode_hdr_max_nits(payload[4])
+                        if avg:
+                            caps["max_avg_luminance"] = avg
+                    if len(payload) >= 6:
+                        mn = decode_hdr_min_nits(payload[5], caps["max_luminance"])
+                        if mn is not None:
+                            caps["min_luminance"] = mn
+                # 14 = HDMI Forum SCDB (VRR)
                 if ext == 0x0E:
-                    vrr = True
+                    caps["vrr"] = True
             if tag == 3 and len(payload) >= 3:
                 oui = (payload[0] << 16) | (payload[1] << 8) | payload[2]
-                # HDMI Forum SCDB, AMD FreeSync
+                # HDMI Forum VSDB, AMD FreeSync
                 if oui in (0xC45DD8, 0x00001A):
-                    vrr = True
+                    caps["vrr"] = True
+                if oui == 0xC45DD8:
+                    caps["bitdepth"] = 10
+                # HDMI 1.4 VSDB: byte 6 carries deep-color flags.
+                if oui == 0x000C03:
+                    hdmi_vsdb = True
+                    if len(payload) >= 7 and payload[6] & 0x70:
+                        hdmi_deep = True
+                        caps["bitdepth"] = 10
 
     walk(data[128:256] if len(data) >= 256 else b"")
     if len(data) >= 384:
@@ -159,8 +200,12 @@ def edid_caps(name):
     if len(data) >= 512:
         walk(data[384:512])
     if b"freesync" in data.lower() or b"adaptive-sync" in data.lower():
-        vrr = True
-    return hdr, vrr
+        caps["vrr"] = True
+    # HDMI VSDB with no DC_30/36/48 flag is a strong 8-bit-only signal.
+    # DP/eDP often omit that block; those stay on 10-bit when HDR is present.
+    if hdmi_vsdb and not hdmi_deep:
+        caps["bitdepth"] = 8
+    return caps
 
 
 def current_mode_id(mon):
@@ -192,15 +237,50 @@ def vrr_mode(mon):
         return 0
 
 
-def parse_lua_vrr(text):
+def parse_lua_monitors(text):
     found = {}
     for block in re.findall(r"hl\.monitor\(\{\s*(.*?)\s*\}\)", text or "", re.S):
         out = re.search(r'output\s*=\s*"([^"]+)"', block)
         if not out or not out.group(1):
             continue
+        entry = {}
         m = re.search(r"vrr\s*=\s*(\d+)", block)
-        found[out.group(1)] = int(m.group(1)) if m else 0
+        if m:
+            entry["vrr"] = int(m.group(1))
+        m = re.search(r"bitdepth\s*=\s*(\d+)", block)
+        if m:
+            entry["bitdepth"] = int(m.group(1))
+        m = re.search(r'cm\s*=\s*"([^"]+)"', block)
+        if m:
+            entry["cm"] = m.group(1)
+        m = re.search(r"sdr_min_luminance\s*=\s*([0-9.]+)", block)
+        if m:
+            entry["sdrMinLuminance"] = float(m.group(1))
+        m = re.search(r"sdr_max_luminance\s*=\s*([0-9.]+)", block)
+        if m:
+            entry["sdrMaxLuminance"] = int(float(m.group(1)))
+        m = re.search(r"(?<![a-z_])min_luminance\s*=\s*([0-9.]+)", block)
+        if m:
+            entry["minLuminance"] = float(m.group(1))
+        m = re.search(r"(?<![a-z_])max_luminance\s*=\s*([0-9.]+)", block)
+        if m:
+            entry["maxLuminance"] = int(float(m.group(1)))
+        found[out.group(1)] = entry
     return found
+
+
+def lua_rule_for(entry, lua_rules):
+    keys = [
+        entry.get("identity") or "",
+        entry.get("name") or "",
+    ]
+    desc = clean_desc(entry.get("description") or "")
+    if desc:
+        keys.append("desc:%s" % desc)
+    for key in keys:
+        if key and key in lua_rules:
+            return lua_rules[key]
+    return {}
 
 
 def read_monitors_lua():
@@ -371,6 +451,13 @@ def stub_monitor(name):
         "hdr": False,
         "hdrCapable": False,
         "vrrCapable": False,
+        "bitdepth": 8,
+        "bitdepthCapable": 8,
+        "sdrMinLuminance": 0.2,
+        "sdrMaxLuminance": 80,
+        "minLuminance": -1,
+        "maxLuminance": -1,
+        "maxAvgLuminance": -1,
         "logicalW": 1920,
         "logicalH": 1080,
         "mode": "preferred",
@@ -401,18 +488,35 @@ def snapshot():
         width = int(mon.get("width") or 0)
         height = int(mon.get("height") or 0)
         lw, lh = logical_size(width, height, scale, transform)
-        hdr_cap, vrr_cap = edid_caps(name)
+        caps = edid_caps(name)
         hdr_on = is_hdr(mon)
         if hdr_on:
-            hdr_cap = True
+            caps["hdr"] = True
         if vrr_mode(mon):
-            vrr_cap = True
-        if not vrr_cap and any(p["refresh"] >= 100 for p in modes):
-            vrr_cap = True
+            caps["vrr"] = True
+        if not caps["vrr"] and any(p["refresh"] >= 100 for p in modes):
+            caps["vrr"] = True
+        fmt = str(mon.get("currentFormat") or "").upper()
+        if any(tok in fmt for tok in ("2101010", "101010", "P010", "P012")):
+            caps["bitdepth"] = 10
         mirror = mon.get("mirrorOf") or ""
         if mirror == "none":
             mirror = ""
         vrr = vrr_mode(mon)
+        cm = mon.get("colorManagementPreset") or "srgb"
+        bitdepth = 10 if hdr_on and caps["bitdepth"] >= 10 else (10 if caps["bitdepth"] >= 10 else 8)
+        if hdr_on and any(tok in fmt for tok in ("XRGB8888", "XR24", "AR24")):
+            bitdepth = 8
+        sdr_min = mon.get("sdrMinLuminance")
+        sdr_max = mon.get("sdrMaxLuminance")
+        try:
+            sdr_min = float(sdr_min) if sdr_min is not None else 0.2
+        except (TypeError, ValueError):
+            sdr_min = 0.2
+        try:
+            sdr_max = int(float(sdr_max)) if sdr_max is not None else 80
+        except (TypeError, ValueError):
+            sdr_max = 80
         entry = {
             "name": name,
             "description": mon.get("description") or "",
@@ -429,11 +533,18 @@ def snapshot():
             "scale": float(scale),
             "transform": transform,
             "vrr": vrr,
-            "cm": mon.get("colorManagementPreset") or "srgb",
+            "cm": cm,
             "format": mon.get("currentFormat") or "",
             "hdr": hdr_on,
-            "hdrCapable": hdr_cap,
-            "vrrCapable": vrr_cap,
+            "hdrCapable": caps["hdr"],
+            "vrrCapable": caps["vrr"],
+            "bitdepth": bitdepth,
+            "bitdepthCapable": 10 if caps["bitdepth"] >= 10 else 8,
+            "sdrMinLuminance": sdr_min,
+            "sdrMaxLuminance": sdr_max,
+            "minLuminance": caps["min_luminance"] if caps["min_luminance"] is not None else -1,
+            "maxLuminance": caps["max_luminance"] if caps["max_luminance"] is not None else -1,
+            "maxAvgLuminance": caps["max_avg_luminance"] if caps["max_avg_luminance"] is not None else -1,
             "logicalW": lw,
             "logicalH": lh,
             "mode": current_mode_id(mon),
@@ -444,13 +555,20 @@ def snapshot():
         }
         entry["identity"] = monitor_identity(entry)
         monitors.append(entry)
-    lua_vrr = parse_lua_vrr(read_monitors_lua())
+    lua_rules = parse_lua_monitors(read_monitors_lua())
+    store_early = load_store()
+    layout_by_id = layout_map(store_early.get("lastLayout"))
     for entry in monitors:
-        key = entry.get("identity") or ""
-        if key in lua_vrr:
-            entry["vrr"] = lua_vrr[key]
-        elif entry.get("name") in lua_vrr:
-            entry["vrr"] = lua_vrr[entry["name"]]
+        saved = layout_by_id.get(entry.get("identity") or "") or {}
+        for key in ("bitdepth", "cm", "sdrMinLuminance", "sdrMaxLuminance", "minLuminance", "maxLuminance"):
+            if key in saved and saved[key] not in (None, ""):
+                entry[key] = saved[key]
+        rule = lua_rule_for(entry, lua_rules)
+        if "vrr" in rule:
+            entry["vrr"] = rule["vrr"]
+        for key in ("bitdepth", "cm", "sdrMinLuminance", "sdrMaxLuminance", "minLuminance", "maxLuminance"):
+            if key in rule:
+                entry[key] = rule[key]
     merge_drm_connected(monitors)
     store = load_store()
     ids = [m["identity"] for m in monitors if m.get("identity")]
@@ -581,7 +699,11 @@ def restore_desk_geometry(monitors):
         rule = hints.get(mon.get("identity") or "")
         if not rule:
             continue
-        for key in ("mode", "x", "y", "scale", "transform", "vrr", "hdr"):
+        for key in (
+            "mode", "x", "y", "scale", "transform", "vrr", "hdr",
+            "bitdepth", "cm", "sdrMinLuminance", "sdrMaxLuminance",
+            "minLuminance", "maxLuminance",
+        ):
             if key in rule:
                 mon[key] = rule[key]
         mon["mirror"] = ""
@@ -783,6 +905,34 @@ def clean_scale(value):
     return round(n, 3)
 
 
+def clean_float(value, lo, hi, default):
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return default
+    if n < lo or n > hi:
+        return default
+    return n
+
+
+def clean_bitdepth(value, default=10):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return 10 if n >= 10 else 8
+
+
+def clean_cm(value):
+    text = str(value or "").strip().lower()
+    return text if text in ("hdr", "hdredid") else "hdr"
+
+
+def format_float(n):
+    text = ("%.4f" % float(n)).rstrip("0").rstrip(".")
+    return text if text else "0"
+
+
 def clean_connector(name):
     text = str(name or "").strip()
     return text if CONNECTOR_RE.match(text) else ""
@@ -809,18 +959,33 @@ def sanitize_monitor(mon, known_names=None):
         "transform": clean_int(mon.get("transform"), 0, 7, 0),
         "vrr": clean_int(mon.get("vrr"), 0, 3, 0),
         "hdr": bool(mon.get("hdr")),
+        "bitdepth": clean_bitdepth(mon.get("bitdepth"), 10),
+        "cm": clean_cm(mon.get("cm")),
+        "sdrMinLuminance": clean_float(mon.get("sdrMinLuminance"), 0.0, 1.0, 0.005),
+        "sdrMaxLuminance": clean_int(mon.get("sdrMaxLuminance"), 40, 1000, 200),
+        "minLuminance": clean_float(mon.get("minLuminance"), 0.0, 10.0, -1),
+        "maxLuminance": clean_int(mon.get("maxLuminance"), -1, 10000, -1),
         "enabled": bool(mon.get("enabled", True)),
         "identity": mon.get("identity") or "",
         "mirror": mirror,
     }
 
 
+INTERNAL_PANEL_RE = re.compile(r"^(eDP|LVDS|DSI)", re.I)
+
+
 def output_ref(mon, used_desc):
+    name = clean_connector(mon.get("name"))
+    # omarchy-hyprland-monitor-clamshell only reads the internal panel's rule
+    # when it is keyed by connector name. Behind a desc: key it finds no scale,
+    # falls back to 2, and re-applies it every 2s while docked.
+    if name and INTERNAL_PANEL_RE.match(name):
+        return name
     desc = clean_desc(mon.get("description") or "")
     if desc and desc not in used_desc:
         used_desc.add(desc)
         return "desc:%s" % desc
-    return clean_connector(mon.get("name")) or "Unknown"
+    return name or "Unknown"
 
 
 def monitor_lua(mon, used_desc):
@@ -839,9 +1004,24 @@ def monitor_lua(mon, used_desc):
     # Persist the integer even when 0. hyprctl often reports VRR as a boolean.
     fields.append("vrr = %d" % int(mon.get("vrr") or 0))
     if mon.get("hdr"):
-        fields.append("bitdepth = 10")
-        fields.append('cm = "hdr"')
+        fields.append("bitdepth = %d" % clean_bitdepth(mon.get("bitdepth"), 10))
+        fields.append("cm = %s" % lua_str(clean_cm(mon.get("cm"))))
         fields.append("supports_hdr = 1")
+        sdr_min = mon.get("sdrMinLuminance")
+        if sdr_min is None:
+            sdr_min = 0.005
+        fields.append("sdr_min_luminance = %s" % format_float(sdr_min))
+        fields.append("sdr_max_luminance = %d" % clean_int(mon.get("sdrMaxLuminance"), 40, 1000, 200))
+        min_lum = mon.get("minLuminance")
+        try:
+            min_lum = float(min_lum)
+        except (TypeError, ValueError):
+            min_lum = -1
+        if min_lum >= 0:
+            fields.append("min_luminance = %s" % format_float(min_lum))
+        max_lum = clean_int(mon.get("maxLuminance"), -1, 10000, -1)
+        if max_lum > 0:
+            fields.append("max_luminance = %d" % max_lum)
     mirror = mon.get("mirror") or ""
     if mirror and mirror not in ("none", name, mon.get("name")):
         fields.append("mirror = %s" % lua_str(mirror))
@@ -1027,6 +1207,12 @@ def profile_entry_from_monitor(mon):
         "transform": int(mon.get("transform") or 0),
         "vrr": int(mon.get("vrr") or 0),
         "hdr": bool(mon.get("hdr")),
+        "bitdepth": clean_bitdepth(mon.get("bitdepth"), 10),
+        "cm": clean_cm(mon.get("cm")),
+        "sdrMinLuminance": clean_float(mon.get("sdrMinLuminance"), 0.0, 1.0, 0.005),
+        "sdrMaxLuminance": clean_int(mon.get("sdrMaxLuminance"), 40, 1000, 200),
+        "minLuminance": clean_float(mon.get("minLuminance"), 0.0, 10.0, -1),
+        "maxLuminance": clean_int(mon.get("maxLuminance"), -1, 10000, -1),
         "enabled": bool(mon.get("enabled", True)),
         "mirror": mon.get("mirror") or "",
     }
@@ -1041,7 +1227,11 @@ def merge_profile(profile, live):
             merged.append(live_m)
             continue
         item = dict(live_m)
-        for key in ("mode", "x", "y", "scale", "transform", "vrr", "hdr", "enabled", "mirror"):
+        for key in (
+            "mode", "x", "y", "scale", "transform", "vrr", "hdr",
+            "bitdepth", "cm", "sdrMinLuminance", "sdrMaxLuminance",
+            "minLuminance", "maxLuminance", "enabled", "mirror",
+        ):
             if key in rule:
                 item[key] = rule[key]
         # Profile mirror is stored as identity; Hyprland wants a connector.

--- a/scripts/display-ctl
+++ b/scripts/display-ctl
@@ -1080,11 +1080,7 @@ def write_original_backup(text):
 
 
 def ensure_original_backup(text=None):
-    """Keep the first unmanaged monitors.lua forever. Never overwrite it.
-
-    Rolling apply backups are separate and get pruned. This file survives
-    plugin remove so someone can go back to the layout they had before Screens.
-    """
+    """Snapshot monitors.lua once, before Screens writes it. Never overwrite."""
     if os.path.isfile(ORIGINAL_BACKUP):
         return False
     if text is None:


### PR DESCRIPTION
Draft for review. Not merged to `main`.

Closes #1. Includes @ced455's connector-name fix from #2.

## What's in 1.5.0

**Layout**
- Panel scrolls only when content is taller than the screen, so 2× scale on 1080p can still reach Scale
- After a scale change, Scale is scrolled into view

**Laptops**
- Built-in panels (`eDP` / `LVDS` / `DSI`) are written by connector name so Omarchy clamshell keeps the scale you set instead of forcing 2
- External monitors still use `desc:` so a dock port change does not drop the rule

**HDR**
- Hyprland HDR is PQ (`hdr` or `hdredid`) at 8-bit or 10-bit. There is no HLG preset
- Bit depth is read from the EDID when possible (HDMI VSDB without deep color → 8-bit; otherwise 10-bit)
- **Tune** next to HDR: 8-bit / 10-bit, HDR PQ / HDR EDID, black floor, SDR peak
- Enabling HDR sets black floor to 0.005 nits (Hyprland's default 0.2 nits lifts dark scenes)

**Display controls**
- Brightness slider on the selected output (internal backlight or DDC); hidden when that output has none
- Brightness labels (Night owl, Golden hour, …) appear in the panel header while you drag
- Text size slider uses Omarchy's 9–20 px stops (`omarchy-display-text-size`)

**Backups**
- First unmanaged `monitors.lua` is copied to `~/.local/state/im0001gt.screens/original-monitors.lua` and never overwritten
- That file lives outside the plugin directory, so `omarchy plugin remove` leaves it
- Restore with `scripts/display-ctl restore-original`

## Test plan

- [ ] Docked laptop: set internal scale to 1×, confirm it holds >5s and `monitors.lua` uses `output = "eDP-1"`
- [ ] External rules still use `desc:`
- [ ] On 1080p, set scale to 2× and confirm the panel scrolls to Scale
- [ ] HDR: Tune shows 8 vs 10 from EDID; override sticks after reload
- [ ] Black floor at 0.005: a black wallpaper should not glow; 0.200 should lift it
- [ ] Brightness slider follows the selected screen; header label changes while dragging
- [ ] Text size stops update the shell (and GTK / terminals)
- [ ] Fresh install: `original-monitors.lua` appears before the first Screens write; `restore-original` puts it back